### PR TITLE
SED-2494 Playwright: updating advanced KW name to avoid conflicts

### DIFF
--- a/keywords/java/demo-playwright-keyword/src/main/java/step/examples/playwright/AdvancedPlaywrightKeywordExample.java
+++ b/keywords/java/demo-playwright-keyword/src/main/java/step/examples/playwright/AdvancedPlaywrightKeywordExample.java
@@ -22,7 +22,7 @@ public class AdvancedPlaywrightKeywordExample extends AbstractKeyword {
     private Page page;
     private BrowserContext context;
 
-    @Keyword(name = "Buy MacBook in OpenCart")
+    @Keyword(name = "Buy MacBook in OpenCart - Advanced")
     public void buyMacBookInOpenCart() throws InterruptedException {
         // Read the URL from the keyword properties. These properties can be defined as Parameter in Step
         page.navigate(properties.computeIfAbsent("opencart.url",

--- a/keywords/java/demo-playwright-keyword/src/test/java/step/examples/playwright/AdvancedPlaywrightKeywordExampleTest.java
+++ b/keywords/java/demo-playwright-keyword/src/test/java/step/examples/playwright/AdvancedPlaywrightKeywordExampleTest.java
@@ -26,7 +26,7 @@ public class AdvancedPlaywrightKeywordExampleTest {
     @Test
     public void test() throws Exception {
         // Call the Keyword with the required Keyword inputs
-        ctx.run("Buy MacBook in OpenCart", "{\"Firstname\":\"Gustav\", \"Lastname\":\"Muster\"}");
+        ctx.run("Buy MacBook in OpenCart - Advanced", "{\"Firstname\":\"Gustav\", \"Lastname\":\"Muster\"}");
     }
 
     @After


### PR DESCRIPTION
Having the same names confuses the wizard, which picks a KW at random(?) and ends up using the advanced one, which doesn't work OOTB because it needs a parameter.